### PR TITLE
Fix: No HTTP Communications

### DIFF
--- a/CookApp/android/app/src/main/AndroidManifest.xml
+++ b/CookApp/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="Cooking"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
For now, we need http communications because the server still doesn't have a certificate.
In production, this setting will be removed as we should have a server with a certificate by then.