### PR TITLE
fix/CKG-0003: ingredient type text in white mode

### DIFF
--- a/cookapp/lib/Pages/Recipe Pages/new_recipe.dart
+++ b/cookapp/lib/Pages/Recipe Pages/new_recipe.dart
@@ -389,8 +389,9 @@ class _NewRecipeFormState extends State<NewRecipeForm> {
                                         ),
                                         DropdownButton<String>(
                                           value: ingsOpts[index],
-                                          style: const TextStyle(
+                                          style: TextStyle(
                                             fontSize: 20,
+                                            color: themeNotifier.value == ThemeMode.dark ? Colors.white : Colors.black,
                                           ),
                                           items: <String>[
                                             'Kg',


### PR DESCRIPTION
## Ingredient Type text
Fixed an issue where the text on the dropdown of the ingredient type was showing as white even on light mode, which was not supposed to happen.

### Before:
![image](https://github.com/user-attachments/assets/37acd1d1-7bc4-475d-9564-60c9487cc6b7)

### After
![image](https://github.com/user-attachments/assets/f572e4b3-5e94-49d2-996b-afe93b90987d)
